### PR TITLE
v0.4.1: CI workflow, vignette catch-up, coerce_type() type_spec support

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,84 @@
+# Standard r-lib R-CMD-check workflow.
+# https://github.com/r-lib/actions/tree/v2/examples
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+name: R-CMD-check
+
+permissions:
+  contents: read
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: ubuntu-latest,  r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
+            any::jsonlite
+            any::yaml
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          error-on: '"warning"'
+          build_args: 'c("--no-manual", "--compact-vignettes=gs+qpdf")'
+
+  lint:
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::lintr, local::.
+          needs: lint
+
+      - name: Lint
+        run: lintr::lint_package()
+        shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: typethis
 Title: Type Safety and Validation for R
-Version: 0.4.0
+Version: 0.4.1
 Authors@R:
     person("TypeThis Team", email = "dev@example.com", role = c("aut", "cre"))
 Description: Provides comprehensive type safety and validation for R, similar to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,31 @@
 # typethis (development version)
 
+## typethis 0.4.1
+
+### Improvements
+
+- `coerce_type()` now accepts a `type_spec` argument for the
+  composable cases where coercion has a clear meaning:
+  `t_nullable()` (NULL passes through, otherwise the inner spec
+  drives the coercion), `t_union()` (each alternative is tried in
+  order; the first that coerces and validates wins), and `t_enum()`
+  (the value is accepted directly if already in the allowed set, or
+  coerced to the enum's value type and re-checked). Other
+  `type_spec` kinds (`t_list_of()`, `t_vector_of()`, `t_model()`,
+  `t_predicate()`) still error, but with a clearer message naming
+  the unsupported kind.
+- README and vignette updated to cover v0.3 (composable type specs,
+  JSON Schema export) and v0.4 (Data Contract bridge).
+
+### Internal
+
+- New test for nested-object registration in `from_datacontract()`
+  (covers the implicit `define_model_in()` side-effect for nested
+  ODCS object properties).
+- New `.github/workflows/R-CMD-check.yaml` runs `R CMD check`
+  (errors on warnings) on macOS, Windows, and Ubuntu (release,
+  devel, oldrel-1) plus a `lintr` job on every push and PR.
+
 ## typethis 0.4.0
 
 ### New Features

--- a/R/type_check.R
+++ b/R/type_check.R
@@ -152,11 +152,7 @@ is_one_of <- function(value, types) {
 #' coerce_type(c(1, 2, 3), "character")
 coerce_type <- function(value, type, strict = FALSE) {
   if (inherits(type, "type_spec")) {
-    stop(
-      "coerce_type() does not support composite type_spec arguments; ",
-      "pass a builtin type name instead",
-      call. = FALSE
-    )
+    return(coerce_type_spec(value, type, strict = strict))
   }
 
   if (is_type(value, type)) {
@@ -189,4 +185,72 @@ coerce_type <- function(value, type, strict = FALSE) {
       ), call. = FALSE)
     }
   )
+}
+
+#' Coerce a value to a `type_spec`
+#'
+#' Supports `t_nullable()` (NULL passes through, otherwise recurses on the
+#' inner spec), `t_union()` (tries each alternative in order, returns the
+#' first that coerces and validates), and `t_enum()` (accepts the value if
+#' it is — possibly after coercion to the enum's value type — in the
+#' allowed set). Other `type_spec` kinds (model_ref, list_of, vector_of,
+#' predicate) are not supported and signal a clear error.
+#'
+#' @keywords internal
+#' @noRd
+coerce_type_spec <- function(value, spec, strict) {
+  switch(spec$kind,
+    "builtin" = coerce_type(value, spec$name, strict = strict),
+    "nullable" = if (is.null(value)) {
+      NULL
+    } else {
+      coerce_type_spec(value, spec$inner, strict = strict)
+    },
+    "union" = coerce_union(value, spec$alternatives, strict),
+    "enum"  = coerce_enum(value, spec, strict),
+    stop(sprintf(
+      "coerce_type() does not support type_spec kind '%s'", spec$kind
+    ), call. = FALSE)
+  )
+}
+
+#' @keywords internal
+#' @noRd
+coerce_union <- function(value, alternatives, strict) {
+  for (alt in alternatives) {
+    success <- TRUE
+    result <- tryCatch(
+      coerce_type_spec(value, alt, strict = strict),
+      error = function(e) {
+        success <<- FALSE
+        NULL
+      }
+    )
+    if (success && is_type(result, alt)) {
+      return(result)
+    }
+  }
+  stop(sprintf(
+    "Failed to coerce to union<%s>: no alternative matched",
+    paste(vapply(alternatives, format, character(1)), collapse = ", ")
+  ), call. = FALSE)
+}
+
+#' @keywords internal
+#' @noRd
+coerce_enum <- function(value, spec, strict) {
+  if (all(value %in% spec$values)) {
+    return(value)
+  }
+  coerced <- tryCatch(
+    coerce_type(value, spec$value_type, strict = strict),
+    error = function(e) NULL
+  )
+  if (!is.null(coerced) && all(coerced %in% spec$values)) {
+    return(coerced)
+  }
+  stop(sprintf(
+    "Failed to coerce to enum<%s>: value not in allowed set",
+    paste(utils::head(as.character(spec$values), 5L), collapse = ", ")
+  ), call. = FALSE)
 }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 - **Typed Functions**: Create type-safe functions with automatic input/output validation
 - **Advanced Validators**: Built-in validators for common patterns (ranges, string patterns, data frames, etc.)
 - **Typed Models**: Define data models with automatic validation (similar to Pydantic)
+- **Composable Type Specs (v0.3+)**: `t_union()`, `t_nullable()`, `t_list_of()`, `t_vector_of()`, `t_enum()`, `t_model()`, `t_predicate()`
+- **JSON Schema Export (v0.3+)**: `to_json_schema()` produces JSON Schema (Draft 2020-12) fragments from typed models, type specs, and validators
+- **Data Contract Bridge (v0.4+)**: `to_datacontract()` / `from_datacontract()` map typed models to and from the Open Data Contract Standard v3
 - **Type Coercion**: Safe type conversion with validation
 - **Custom Validators**: Easy to create custom validation logic
 

--- a/tests/testthat/test-datacontract.R
+++ b/tests/testthat/test-datacontract.R
@@ -281,6 +281,49 @@ test_that("from_datacontract round-trips an exported contract", {
   expect_true(is.function(imported_fields$qty$validator))
 })
 
+test_that("from_datacontract registers nested object properties as models", {
+  skip_without_yaml()
+  options(typethis_model_registry = list())
+  on.exit(options(typethis_model_registry = list()), add = TRUE)
+  contract <- list(
+    apiVersion = "v3.0.2",
+    kind = "DataContract",
+    name = "demo",
+    version = "1.0.0",
+    schema = list(
+      list(
+        name = "Customer",
+        logicalType = "object",
+        properties = list(
+          list(name = "id", logicalType = "string",
+               required = TRUE, primaryKey = TRUE),
+          list(
+            name = "address",
+            logicalType = "object",
+            properties = list(
+              list(name = "street", logicalType = "string", required = TRUE),
+              list(name = "city",   logicalType = "string", required = TRUE)
+            )
+          )
+        )
+      )
+    )
+  )
+  env <- new.env()
+  from_datacontract(contract, register = TRUE, envir = env)
+
+  expect_true(exists("new_Customer", envir = env))
+  expect_true(exists("new_address",  envir = env))
+  expect_true(exists("update_address", envir = env))
+
+  reg <- getOption("typethis_model_registry")
+  expect_true(all(c("Customer", "address") %in% names(reg)))
+  expect_equal(names(reg$address$fields), c("street", "city"))
+
+  addr <- env$new_address(street = "Main 1", city = "Munich")
+  expect_true(is_model(addr))
+})
+
 # ---------------------------------------------------------------------------
 # Error paths
 # ---------------------------------------------------------------------------

--- a/tests/testthat/test-type_check.R
+++ b/tests/testthat/test-type_check.R
@@ -57,3 +57,46 @@ test_that("coerce_type handles errors", {
     "Coercion to numeric resulted in NA"
   )
 })
+
+test_that("coerce_type accepts t_nullable", {
+  spec <- t_nullable("numeric")
+  expect_null(coerce_type(NULL, spec))
+  expect_equal(coerce_type("123", spec), 123)
+  expect_equal(coerce_type(5, spec), 5)
+})
+
+test_that("coerce_type accepts t_union by trying alternatives in order", {
+  spec <- t_union("integer", "character")
+  # "5" is already character → returned as-is by the character branch
+  expect_equal(coerce_type("5", spec), "5")
+  # 5 is numeric: integer alternative succeeds via as.integer()
+  expect_equal(coerce_type(5, spec), 5L)
+})
+
+test_that("coerce_type errors when no union alternative matches", {
+  spec <- t_union("integer", "logical")
+  expect_error(
+    coerce_type(list(1, 2), spec),
+    "no alternative matched"
+  )
+})
+
+test_that("coerce_type accepts t_enum", {
+  spec <- t_enum(c("admin", "user"))
+  expect_equal(coerce_type("admin", spec), "admin")
+  expect_error(
+    coerce_type("guest", spec),
+    "value not in allowed set"
+  )
+})
+
+test_that("coerce_type rejects unsupported type_spec kinds with clear error", {
+  expect_error(
+    coerce_type(list(1, 2), t_list_of("integer")),
+    "type_spec kind 'list_of'"
+  )
+  expect_error(
+    coerce_type(5, t_predicate(function(x) x > 0)),
+    "type_spec kind 'predicate'"
+  )
+})

--- a/vignettes/typethis-guide.Rmd
+++ b/vignettes/typethis-guide.Rmd
@@ -326,6 +326,41 @@ optional_num(NULL)
 optional_num("hello")
 ```
 
+## Composable Type Specs (v0.3+)
+
+Beyond plain type names like `"numeric"`, `typethis` provides a small set of constructors that compose into richer specifications. They work everywhere a type name does — `is_type()`, `assert_type()`, `typed_function()`, and `field()`.
+
+```{r}
+# Either an integer or a character
+spec <- t_union("integer", "character")
+is_type(1L, spec)
+is_type("x", spec)
+is_type(1.5, spec)
+
+# A value that may also be NULL
+maybe_num <- t_nullable("numeric")
+is_type(NULL, maybe_num)
+is_type(3.14, maybe_num)
+
+# A list whose elements are all integers, or a vector of them
+is_type(list(1L, 2L, 3L), t_list_of("integer"))
+is_type(c(1L, 2L, 3L), t_vector_of("integer"))
+
+# A finite enumeration
+status <- t_enum(c("active", "inactive", "pending"))
+is_type("active", status)
+is_type("deleted", status)
+```
+
+Specs compose freely. The example below accepts a list whose elements are each either an integer or a character:
+
+```{r}
+mixed <- t_list_of(t_union("integer", "character"))
+is_type(list(1L, "two", 3L), mixed)
+```
+
+Use `is_type_spec()` to detect a composite spec, and pass any spec to `field()` when defining a model.
+
 ## Typed Models
 
 The most powerful feature of `typethis` - create typed data models with automatic validation.
@@ -467,6 +502,76 @@ result$valid
 # Convert to list
 person_list <- model_to_list(person)
 person_list
+```
+
+## JSON Schema Export (v0.3+)
+
+`to_json_schema()` serializes typed models, type specs, and validators into a JSON Schema (Draft 2020-12) fragment. Builtin validator factories (`numeric_range()`, `string_length()`, `string_pattern()`, `enum_validator()`, ...) attach a `constraint` attribute to their closure that the exporter reads — so range and pattern constraints surface as native `minimum` / `maxLength` / `pattern` keys.
+
+```{r json-schema, eval = requireNamespace("jsonlite", quietly = TRUE)}
+define_model("Account",
+  fields = list(
+    id      = field("integer", validator = numeric_range(min = 1L)),
+    email   = field("character", validator = string_pattern("^[^@]+@[^@]+$")),
+    role    = field("character", validator = enum_validator(c("admin", "user"))),
+    tags    = field(t_list_of("character"), default = list())
+  )
+)
+
+schema <- to_json_schema("Account")
+jsonlite::toJSON(schema, auto_unbox = TRUE, pretty = TRUE)
+```
+
+Constructs without a canonical JSON Schema mapping (data frames, factors, custom predicate functions) are emitted as `x-typethis-*` extension keys so that the schema round-trips through typethis-aware tooling without losing information. Nested models become `$ref` entries with auto-populated `$defs`; cyclic references are handled via a stub-then-fill protocol.
+
+## Data Contracts (ODCS v3, v0.4+)
+
+The `to_datacontract()` / `from_datacontract()` bridge maps typed models to and from the [Open Data Contract Standard v3](https://github.com/bitol-io/open-data-contract-standard). `field()` accepts ODCS metadata arguments — `primary_key`, `unique`, `pii`, `classification`, `tags`, `examples`, `references`, `quality` — that round-trip through the contract but have no effect on runtime validation.
+
+```{r datacontract, eval = requireNamespace("yaml", quietly = TRUE)}
+define_model("Customer",
+  fields = list(
+    customer_id = field("integer",
+      primary_key = TRUE,
+      unique = TRUE,
+      description = "Surrogate key"
+    ),
+    email = field("character",
+      pii = TRUE,
+      classification = "confidential",
+      validator = string_pattern("^[^@]+@[^@]+$")
+    ),
+    signup_date = field("date",
+      tags = c("audit", "lifecycle")
+    )
+  )
+)
+
+contract <- to_datacontract("Customer",
+  info = list(name = "Customers", version = "1.0.0")
+)
+str(contract, max.level = 2)
+```
+
+Write the contract to disk with `write_datacontract()` and read it back with `from_datacontract()` (which also re-registers the schemas as `new_*()` constructors in the calling environment):
+
+```{r datacontract-roundtrip, eval = requireNamespace("yaml", quietly = TRUE)}
+tmp <- tempfile(fileext = ".yaml")
+write_datacontract("Customer", tmp,
+  info = list(name = "Customers", version = "1.0.0")
+)
+
+env <- new.env()
+from_datacontract(tmp, envir = env)
+ls(env)
+```
+
+For full validation against the standard, the upstream [`datacontract` CLI](https://datacontract.com) is available through thin wrappers — `datacontract_lint()`, `datacontract_test()`, `datacontract_export()` — gated by `datacontract_cli_available()`:
+
+```{r datacontract-cli, eval = FALSE}
+if (datacontract_cli_available()) {
+  datacontract_lint(tmp)
+}
 ```
 
 ## Real-World Examples


### PR DESCRIPTION
- Add .github/workflows/R-CMD-check.yaml: standard r-lib check across
  macOS / Windows / Ubuntu (release, devel, oldrel-1) with
  error-on=warning, plus a lintr job. Activates the R-CMD-check badge
  in README.md.
- Vignette now covers v0.3 (composable type specs, JSON Schema export)
  and v0.4 (Data Contract bridge with ODCS metadata, write/read round
  trip, optional CLI wrappers). README features list updated.
- coerce_type() accepts t_nullable() (NULL passes through, otherwise
  recurses on inner spec), t_union() (first alternative that coerces
  and validates wins) and t_enum() (accepts directly or coerces to
  the enum value type and re-checks). Other type_spec kinds still
  error, with a clearer message naming the unsupported kind.
- New test for nested-object registration in from_datacontract()
  covering the implicit define_model_in() side-effect at
  R/datacontract.R:700-707.
- Bump DESCRIPTION to 0.4.1, add NEWS entry.