### PR TITLE
ci: add pkgdown deploy workflow and config

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,6 @@
 ^ROADMAP\.md$
 ^specs$
 ^\.lintr$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,5 +19,5 @@ Suggests:
     jsonlite (>= 1.8.0),
     yaml (>= 2.3.0)
 Config/testthat/edition: 3
-URL: https://github.com/fabiandistler/typethis
+URL: https://fabiandistler.github.io/typethis/, https://github.com/fabiandistler/typethis
 BugReports: https://github.com/fabiandistler/typethis/issues

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,3 @@
+url: https://fabiandistler.github.io/typethis/
+template:
+  bootstrap: 5


### PR DESCRIPTION
Replicates usethis::use_pkgdown_github_pages(): adds the standard
r-lib/actions pkgdown workflow, a minimal _pkgdown.yml with the Pages
URL and Bootstrap 5 template, .Rbuildignore entries for the pkgdown
artefacts, and the docs URL in DESCRIPTION.