### PR TITLE
Add lintr workflow for R code analysis

### DIFF
--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -36,10 +36,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@4e1feaf90520ec1215d1882fdddfe3411c08e492
+        uses: r-lib/actions/setup-r@v2
 
       - name: Setup lintr
-        uses: r-lib/actions/setup-r-dependencies@4e1feaf90520ec1215d1882fdddfe3411c08e492
+        uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: lintr
 

--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -1,0 +1,55 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# lintr provides static code analysis for R.
+# It checks for adherence to a given style,
+# identifying syntax errors and possible semantic issues,
+# then reports them to you so you can take action.
+# More details at https://lintr.r-lib.org/
+
+name: lintr
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '21 23 * * 3'
+
+permissions:
+  contents: read
+
+jobs:
+  lintr:
+    name: Run lintr scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@4e1feaf90520ec1215d1882fdddfe3411c08e492
+
+      - name: Setup lintr
+        uses: r-lib/actions/setup-r-dependencies@4e1feaf90520ec1215d1882fdddfe3411c08e492
+        with:
+          extra-packages: lintr
+
+      - name: Run lintr
+        run: lintr::sarif_output(lintr::lint_dir("."), "lintr-results.sarif")
+        shell: Rscript {0}
+        continue-on-error: true
+
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: lintr-results.sarif
+          wait-for-processing: true


### PR DESCRIPTION
This workflow sets up lintr for static code analysis of R code, triggered on pushes and pull requests to the main branch, as well as on a schedule.