### PR TITLE
docs: bump to 0.8.0 with whole-package retrofit NEWS entry

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: typethis
 Title: Type Safety and Validation for R
-Version: 0.7.0
+Version: 0.8.0
 Authors@R:
     person("Fabian Distler", email = "dev@example.com", role = c("aut", "cre"))
 Description: Provides comprehensive type safety and validation for R, similar to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,56 @@
 # typethis (development version)
 
+## typethis 0.8.0
+
+### New Features
+
+#### Whole-package retrofit
+
+- `enable_for_package()` runs `as_typed()` over every exported function
+  of an installed package's namespace in one call. Per-function specs
+  flow through `.specs = list(funA = list(...))`; an optional `.filter`
+  predicate narrows the set of functions touched. Already-typed
+  functions go through `as_typed()`'s idempotent merge path.
+
+#### Roxygen-driven retrofit
+
+- `as_typed_from_roxygen()` reads installed `.Rd` files (or a source
+  `man/` directory via `.rd_dir`), extracts a type spec for each
+  documented `\arguments` item and `\value` block, then forwards the
+  result via `enable_for_package()`. Two extraction layers run in
+  sequence: an explicit `[type]` prefix at the start of the description,
+  and a vocabulary heuristic against `default_type_vocabulary()` that
+  maps leading prose like "A numeric vector" or "If TRUE" to the
+  corresponding builtin spec. Rd-derived specs are pruned to formals
+  that actually exist on each function; user-supplied `.specs` win on
+  conflict.
+- `parse_param_type()` is exported so users can preview what would be
+  derived from a single description string.
+- `default_type_vocabulary()` is exported so users can extend or
+  replace the prose-to-spec map.
+
+#### Zero-touch namespace retrofit
+
+- `enable_typed_namespace()` registers a
+  `setHook(packageEvent(pkg, "onLoad"), ...)` handler that runs
+  `enable_for_package()` over the namespace each time it loads. If the
+  package is already loaded when called, the retrofit also applies
+  immediately to the live namespace. Because the hook fires after R
+  locks the namespace bindings, the retrofit goes through an
+  unlock-modify-relock dance, with re-locking guaranteed by `on.exit`.
+- `disable_typed_namespace()` is the inverse: it removes
+  typethis-tagged hooks from the package event (foreign hooks are left
+  intact) and, by default, walks the loaded namespace to revert each
+  typed wrapper to its inner function.
+- `as_typed_env()` gained a `.unlock` parameter. When `TRUE`, locked
+  bindings are unlocked, reassigned to their typed wrapper, and
+  re-locked instead of skipped + warned. `enable_for_package()`
+  forwards the same `.unlock` through.
+
+This pattern is meant for development and exploratory use, not for
+CRAN-bound code: modifying namespaces you do not own is a developer
+convenience. See `vignette("package-wide")` for the full walkthrough.
+
 ## typethis 0.7.0
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ devtools::install_github("fabiandistler/typethis")
   Schema](https://json-schema.org/) (Draft 2020-12), [Open Data Contract
   Standard v3](https://bitol-io.github.io/open-data-contract-standard/),
   and [OpenAPI 3.1](https://spec.openapis.org/oas/v3.1.0) without leaving R.
+- **Retrofit a whole package.** `enable_for_package()`,
+  `as_typed_from_roxygen()`, and `enable_typed_namespace()` add type
+  checks across an existing package without rewriting its functions.
 
 ## A 30-second tour
 
@@ -97,6 +100,7 @@ follow the topic that matches what you want to do.
 | [`vignette("validators-and-models")`](vignettes/validators-and-models.Rmd) | All built-in validators and how to combine them; nested and strict models; field metadata. |
 | [`vignette("type-specs")`](vignettes/type-specs.Rmd) | Composable type specifications with the `t_*()` family. |
 | [`vignette("interop")`](vignettes/interop.Rmd) | JSON Schema, Open Data Contract Standard, and OpenAPI 3.1 export and import. |
+| [`vignette("package-wide")`](vignettes/package-wide.Rmd) | Retrofit type checks across an existing package without rewriting its functions. |
 
 For the full function reference see `?typethis` (a topic-grouped index of
 every exported function) or the individual help pages. Function help is
@@ -113,6 +117,7 @@ functions in the "Typed functions" family via `seealso`.
 | `numeric_range()`, `string_pattern()`, `enum_validator()`, … | Add value-level rules on top of types. |
 | `t_union()`, `t_nullable()`, `t_list_of()`, `t_enum()`, … | Build a richer type spec inline (e.g. `t_list_of(t_union("integer", "character"))`). |
 | `to_json_schema()` / `to_datacontract()` / `to_openapi()` | Hand the same definitions to non-R systems. |
+| `enable_for_package()` / `as_typed_from_roxygen()` / `enable_typed_namespace()` | Retrofit type checks across an existing package without rewriting its functions. |
 
 ## Runtime only
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,45 @@
 # typethis Roadmap
 
-## v0.5 (current)
+## v0.8 (current)
+
+Whole-package type retrofit lands in v0.8 as three connected features:
+
+1. **`enable_for_package()`** runs `as_typed()` over every exported
+   function in an installed package's namespace, with optional
+   per-function `.specs` and a `.filter` predicate.
+2. **`as_typed_from_roxygen()`** lifts type specs out of installed
+   `.Rd` files via an explicit `[type]` prefix or a vocabulary
+   heuristic (`default_type_vocabulary()`), and forwards the result
+   through `enable_for_package()`. `parse_param_type()` is the
+   single-description preview helper.
+3. **`enable_typed_namespace()`** / **`disable_typed_namespace()`**
+   register a `setHook(packageEvent(pkg, "onLoad"), ...)` handler that
+   applies the retrofit on every load (and immediately if the namespace
+   is already loaded), going through an unlock-modify-relock dance.
+   `as_typed_env()` and `enable_for_package()` gained a matching
+   `.unlock` parameter.
+
+This pattern is for development and exploratory use, not CRAN-bound
+code. See `vignette("package-wide")`.
+
+## v0.7
+
+1. **`as_typed_env()`** retrofits every function in an environment in
+   one call, with `.specs` for per-function overrides and `.filter`
+   to narrow the set.
+2. **`types(f)` / `types(f) <- value`** is a symmetric replacement-form
+   accessor over `as_typed()`. `types(g) <- types(f)` round-trips;
+   `types(f) <- NULL` un-types `f`.
+
+## v0.6
+
+1. **`as_typed()`** wraps an existing function with type checks via
+   `...` argument specs. Specs for arguments with literal atomic
+   defaults are inferred automatically; `as_typed()` is idempotent.
+2. **`infer_specs()`** returns the inferred argument specs for a
+   function as a named list.
+
+## v0.5
 
 A single feature lands in v0.5:
 


### PR DESCRIPTION
Catches version and changelog up to PR #47. NEWS.md gains a 0.8.0 block
covering enable_for_package(), as_typed_from_roxygen() (plus
parse_param_type() and default_type_vocabulary()), and
enable_typed_namespace() / disable_typed_namespace() including the
.unlock path on as_typed_env(). README surfaces the new entry points
and links the package-wide vignette; ROADMAP catches up with v0.6/v0.7
landed work alongside the new v0.8 block.